### PR TITLE
Added exclude filter

### DIFF
--- a/assets/js/controllers/AppCtrl.coffee
+++ b/assets/js/controllers/AppCtrl.coffee
@@ -20,6 +20,7 @@ app.controller 'AppCtrl', [
         bestLimit: null
         blacklist: []
         searchText: ''
+        excludeText: ''
     resetExperimentData()
 
     findFeaturesFromIds = (featureIds) ->

--- a/assets/js/controllers/AppCtrl.coffee
+++ b/assets/js/controllers/AppCtrl.coffee
@@ -203,6 +203,10 @@ app.controller 'AppCtrl', [
       # Simple text filter
       filtered = $scope.features.filter (feature) ->
           (feature.name.search $scope.filterParams.searchText) != -1
+      # Text filter that excludes features
+      if $scope.filterParams.excludeText? and $scope.filterParams.excludeText.length > 0
+        filtered = filtered.filter (feature) ->
+            (feature.name.search $scope.filterParams.excludeText) == -1
 
       # Blacklist filter
       if $scope.filterParams.blacklist?
@@ -233,6 +237,7 @@ app.controller 'AppCtrl', [
         bestLimit: newValue.bestLimit
         blacklist: newValue.blacklist.map (f) -> f.id
         searchText: newValue.searchText
+        excludeText: newValue.excludeText
       backendService.getExperiment()
         .then (experiment) -> experiment.setFilterParams serialized
         .fail console.error

--- a/assets/js/controllers/AppCtrl.coffee
+++ b/assets/js/controllers/AppCtrl.coffee
@@ -161,6 +161,7 @@ app.controller 'AppCtrl', [
       filterParams = experiment.getFilterParams()
       $scope.filterParams.bestLimit = filterParams.bestLimit
       $scope.filterParams.searchText = filterParams.searchText
+      $scope.filterParams.excludeText = filterParams.excludeText
       return
 
     backendService.getExperiment()

--- a/assets/js/directives/searchBar.coffee
+++ b/assets/js/directives/searchBar.coffee
@@ -15,6 +15,8 @@ app.directive 'searchBar', [
             return
           if searchedItem.isTextFilter
             scope.filterParams.searchText = searchedItem.feature.name
+          else if searchedItem.isExcludeFilter
+            scope.filterParams.excludeText = searchedItem.feature.name
           else
             $location.path "/feature/#{searchedItem.feature.name}"
             scope.mapApi.locateFeature searchedItem.feature
@@ -27,16 +29,22 @@ app.directive 'searchBar', [
             isTextFilter: true
             feature:
               name: scope.searchText
+          searchItems.push
+            isExcludeFilter: true
+            feature:
+              name: scope.searchText
 
           searchItems = searchItems.concat scope.filteredFeatures.map (feature) ->
             return {
               feature: feature
-              isTextFilter: false
             }
           return searchItems
 
         scope.resetTextFilter = ->
           scope.filterParams.searchText = ''
+
+        scope.resetExcludeFilter = ->
+          scope.filterParams.excludeText = ''
 
         scope.chipsExpanded = false
         scope.maxChipsPreviewed = 2

--- a/assets/js/services/backendService.coffee
+++ b/assets/js/services/backendService.coffee
@@ -127,7 +127,7 @@ app.factory 'backendService', [
             visibility_text_filter: filterParams.searchText
             visibility_rank_filter: filterParams.bestLimit
             visibility_blacklist: filterParams.blacklist
-            visibilty_exclude_filter: filterParams.excludeText
+            visibility_exclude_filter: filterParams.excludeText
           .fail console.error
 
       getFilterParams: =>

--- a/assets/js/services/backendService.coffee
+++ b/assets/js/services/backendService.coffee
@@ -114,6 +114,7 @@ app.factory 'backendService', [
           bestLimit: json.visibility_rank_filter
           blacklist: json.visibility_blacklist
           searchText: json.visibility_text_filter
+          excludeText: json.visibility_exclude_filter
         return experiment
 
       makeCurrent: =>
@@ -126,6 +127,7 @@ app.factory 'backendService', [
             visibility_text_filter: filterParams.searchText
             visibility_rank_filter: filterParams.bestLimit
             visibility_blacklist: filterParams.blacklist
+            visibilty_exclude_filter: filterParams.excludeText
           .fail console.error
 
       getFilterParams: =>

--- a/assets/styles/searchBar.less
+++ b/assets/styles/searchBar.less
@@ -47,6 +47,10 @@ search-bar {
       }
     }
 
+    .text-filter {
+      margin: -8px;
+    }
+
     .filter-icon {
       margin-right: 16px;
       margin-left: 10px;

--- a/assets/styles/searchBar.less
+++ b/assets/styles/searchBar.less
@@ -66,3 +66,23 @@ search-bar {
 
     }
 }
+
+.search-item{
+  height: 100%;
+
+  .search-text {
+    height: 100%;
+    display: table;
+
+    p {
+      height: 100%;
+      vertical-align: middle;
+      display:table-cell;
+      text-align:center;
+      white-space: normal;
+      margin: 0px;
+      margin-left: 4px;
+      line-height: 1.2;
+    }
+  }
+}

--- a/assets/templates/searchBar.jade
+++ b/assets/templates/searchBar.jade
@@ -10,18 +10,24 @@ form.overlay-window(ng-submit='$event.preventDefault()',ng-cloak)
                     placeholder='Search for feature')
       md-item-template
         span.item-title
-          md-icon {{item.isTextFilter ? 'filter_list' : 'search'}}
+          md-icon {{item.isTextFilter || item.isExcludeFilter ? 'filter_list' : 'search'}}
           span
-            {{item.isTextFilter ? 'Filter features by \'' : 'Locate feature '}}
+            {{ item.isTextFilter ? 'Show \'' : item.isExcludeFilter ? 'Exclude \'' : 'Locate feature ' }}
             span(md-highlight-text='searchText', md-highlight-flags='^i') {{item.feature.name}}
-            {{item.isTextFilter ? '\'' : ''}}
+            {{item.isTextFilter || item.isExcludeFilter ? '\'' : ''}}
       md-not-found No feature found
-  #filter-info.md-whiteframe-z1(layout='column', ng-show='filterParams.searchText.length > 0 || filterParams.blacklist.length > 0')
+  #filter-info.md-whiteframe-z1(layout='column', ng-show='filterParams.searchText.length > 0 || filterParams.blacklist.length > 0 || filterParams.excludeText.length > 0')
     div(layout='row', ng-show='filterParams.searchText.length > 0')
       md-icon.filter-icon filter_list
-      p {{filterParams.searchText}}
+      p '{{filterParams.searchText}}' in name
       span(flex)
       md-button.md-icon-button.reset-filter-button(ng-click='resetTextFilter()')
+        md-icon close
+    div(layout='row', ng-show='filterParams.excludeText.length > 0')
+      md-icon.filter-icon filter_list
+      p '{{filterParams.excludeText}}' not in name
+      span(flex)
+      md-button.md-icon-button.reset-filter-button(ng-click='resetExcludeFilter()')
         md-icon close
     div(layout='row', ng-show='filterParams.blacklist.length > 0')
       md-chips(flex)

--- a/assets/templates/searchBar.jade
+++ b/assets/templates/searchBar.jade
@@ -12,18 +12,18 @@ form.overlay-window(ng-submit='$event.preventDefault()',ng-cloak)
         span.item-title
           md-icon {{item.isTextFilter || item.isExcludeFilter ? 'filter_list' : 'search'}}
           span
-            {{ item.isTextFilter ? 'Show \'' : item.isExcludeFilter ? 'Exclude \'' : 'Locate feature ' }}
+            {{ item.isTextFilter ? 'Show only matching \'' : item.isExcludeFilter ? 'Exclude matching \'' : 'Locate feature ' }}
             span(md-highlight-text='searchText', md-highlight-flags='^i') {{item.feature.name}}
             {{item.isTextFilter || item.isExcludeFilter ? '\'' : ''}}
       md-not-found No feature found
   #filter-info.md-whiteframe-z1(layout='column', ng-show='filterParams.searchText.length > 0 || filterParams.blacklist.length > 0 || filterParams.excludeText.length > 0')
-    div(layout='row', ng-show='filterParams.searchText.length > 0')
+    div.text-filter(layout='row', ng-show='filterParams.searchText.length > 0')
       md-icon.filter-icon filter_list
       p '{{filterParams.searchText}}' in name
       span(flex)
       md-button.md-icon-button.reset-filter-button(ng-click='resetTextFilter()')
         md-icon close
-    div(layout='row', ng-show='filterParams.excludeText.length > 0')
+    div.text-filter(layout='row', ng-show='filterParams.excludeText.length > 0')
       md-icon.filter-icon filter_list
       p '{{filterParams.excludeText}}' not in name
       span(flex)

--- a/assets/templates/searchBar.jade
+++ b/assets/templates/searchBar.jade
@@ -9,12 +9,14 @@ form.overlay-window(ng-submit='$event.preventDefault()',ng-cloak)
                     md-items='item in getSearchItems() | filter:{feature:{name: searchText}}',
                     placeholder='Search for feature')
       md-item-template
-        span.item-title
+        span.search-item(layout='row')
           md-icon {{item.isTextFilter || item.isExcludeFilter ? 'filter_list' : 'search'}}
-          span
-            {{ item.isTextFilter ? 'Show only matching \'' : item.isExcludeFilter ? 'Exclude matching \'' : 'Locate feature ' }}
-            span(md-highlight-text='searchText', md-highlight-flags='^i') {{item.feature.name}}
-            {{item.isTextFilter || item.isExcludeFilter ? '\'' : ''}}
+          div.search-text
+            p
+              {{ item.isTextFilter ? 'Show only matching \'' : item.isExcludeFilter ? 'Exclude matching \'' : 'Locate feature ' }}
+              span(md-highlight-text='searchText', md-highlight-flags='^i') {{item.feature.name}}
+              {{item.isTextFilter || item.isExcludeFilter ? '\'' : ''}}
+          span(flex)
       md-not-found No feature found
   #filter-info.md-whiteframe-z1(layout='column', ng-show='filterParams.searchText.length > 0 || filterParams.blacklist.length > 0 || filterParams.excludeText.length > 0')
     div.text-filter(layout='row', ng-show='filterParams.searchText.length > 0')

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -35,6 +35,7 @@ html(ng-app='predots')
           + Use a different or additional preprocessor, like SASS, SCSS or Stylus
 
     // STYLES
+    link(rel="stylesheet", href="/vendor/angular-material-expansion-panel/md-expansion-panel.css")
     link(rel="stylesheet", href="/vendor/angular-material/angular-material.css")
     link(rel="stylesheet", href="/vendor/angularjs-slider/rzslider.css")
     link(rel="stylesheet", href="/vendor/nvd3/nv.d3.css")
@@ -96,6 +97,7 @@ html(ng-app='predots')
     script(src="/vendor/nvd3/nv.d3.js")
     script(src="/vendor/angular-animate/angular-animate.js")
     script(src="/vendor/angular-aria/angular-aria.js")
+    script(src="/vendor/angular-material-expansion-panel/md-expansion-panel.js")
     script(src="/vendor/angular-material/angular-material.js")
     script(src="/vendor/angular-messages/angular-messages.js")
     script(src="/vendor/angular-nvd3/angular-nvd3.js")

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -35,7 +35,6 @@ html(ng-app='predots')
           + Use a different or additional preprocessor, like SASS, SCSS or Stylus
 
     // STYLES
-    link(rel="stylesheet", href="/vendor/angular-material-expansion-panel/md-expansion-panel.css")
     link(rel="stylesheet", href="/vendor/angular-material/angular-material.css")
     link(rel="stylesheet", href="/vendor/angularjs-slider/rzslider.css")
     link(rel="stylesheet", href="/vendor/nvd3/nv.d3.css")
@@ -97,7 +96,6 @@ html(ng-app='predots')
     script(src="/vendor/nvd3/nv.d3.js")
     script(src="/vendor/angular-animate/angular-animate.js")
     script(src="/vendor/angular-aria/angular-aria.js")
-    script(src="/vendor/angular-material-expansion-panel/md-expansion-panel.js")
     script(src="/vendor/angular-material/angular-material.js")
     script(src="/vendor/angular-messages/angular-messages.js")
     script(src="/vendor/angular-nvd3/angular-nvd3.js")


### PR DESCRIPTION
See #114.
In action:
[Search box](https://puu.sh/waVlu/bb6ad4c0a5.png)  
[Filter active](https://puu.sh/waVtN/19416694a9.png)  

Saving the property is implemented in the front end, but not supported by the backend yet. All that needs to be done is adding a property `visibilty_exclude_filter`.
